### PR TITLE
feat (colors): define global color palette in :root

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -29,3 +29,12 @@
     font-style: normal;
 }
 
+/* COLOR SETTINGS */
+
+:root{
+    --primary : #17abb3;
+    --dark : #333333;
+    --grey : #e3e3e3;
+    --light-grey : #f5f5f5;
+    --white : #ffffff;
+}


### PR DESCRIPTION
Expose the color palette from the brief for easy reuse.

- In `style.css` add CSS variables in `:root` :
--primary : #17abb3
--dark : #333333
--grey : #e3e3e3
--light-grey : #f5f5f5
--white : #ffffff

Closes #4 