### PR TITLE
fix (header): ensure links open safely and group contact list

### DIFF
--- a/assets/css/_header.css
+++ b/assets/css/_header.css
@@ -79,3 +79,9 @@ header li img {
     width: 20px;
     height: 20px;
 }
+
+header li a{
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}

--- a/index.html
+++ b/index.html
@@ -27,23 +27,28 @@
         <!-- Informations personnelles -->
         <ul aria-label="Coordonnées et informations">
           <li>
-            <img src="assets/img/icons/envelope.svg" alt="" aria-hidden="true"/>
             <a href="mailto:cedrickernec.ck@gmail.com"
-              >cedrickernec.ck@gmail.com</a
-            >
-          </li>
-          <li>
-            <img src="assets/img/icons/house.svg" alt="" aria-hidden="true"/>
-            <a
-              href="https://www.google.com/maps?q=Kergrosse,+56410+Erdeven"
               target="_blank"
-              rel="noopener noreferrer"
-              >Kergrosse, 56410 Erdeven</a
-            >
+              rel="noopener noreferrer">
+                <img src="assets/img/icons/envelope.svg" alt="" aria-hidden="true"/>
+                cedrickernec.ck@gmail.com
+            </a>
           </li>
           <li>
-            <img src="assets/img/icons/phone.svg" alt="" aria-hidden="true"/>
-            <a href="tel:+33638056898">06 38 05 68 98</a>
+            <a href="https://www.google.com/maps?q=Kergrosse,+56410+Erdeven"
+              target="_blank"
+              rel="noopener noreferrer">
+              <img src="assets/img/icons/house.svg" alt="" aria-hidden="true"/>
+              Kergrosse, 56410 Erdeven
+            </a>
+          </li>
+          <li>
+            <a href="tel:+33638056898"
+            target="_blank"
+            rel="noopener noreferrer">
+                <img src="assets/img/icons/phone.svg" alt="" aria-hidden="true"/>
+                06 38 05 68 98
+            </a>
           </li>
           <li>
             <img src="assets/img/icons/car.svg" alt="" aria-hidden="true"/>


### PR DESCRIPTION
- Group each icon + text in a single  link (instead of having the icon separate)
- Check that the `mailto:` and `tel:` links open the email/phone software correctly and ensure this open safely
- Check that the focus (tab) surrounds the icon + text as a whole

Close #29 